### PR TITLE
Allow for using ARNs to check other accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,31 @@ aws_access_key_id = "Your Access Key Id"
 aws_secret_access_key = "Your Secret Key Id"
 ```
 
+### Using AWS ARNs
+
+If you have an Access and Secret key for one account, but need to monitoring instances in a different account, you need to make use of AWS roles and ARNs (Amazon Resource Name).
+
+Assuming Account A is the one you have the Access and Secret keys for, and Account B is the one you want to monitor instances in, follow these steps:
+
+* In Account A, within IAM->Users->"Username" for your user with the access key, get the 12 digit UserID (the number within the 'User ARN' on the Summary page)
+
+* In Account B, go to IAM->Roles->Create Role->Another AWS Account, enter the 12 digit number (leave all other options as default), click Next to go to Permissions and assign at least "AmazonEC2ReadOnlyAccess" and "CloudWatchReadOnlyAccess".  Make a note of the ARN when the role is created.
+
+* In Account A, within IAM->Policies->Create Policy, provide a suitable group name (such as 'AccessToEC2InAccountXXX') enter the following JSON, putting in the ARN from the previous step
+
+```
+{
+    "Version": "2012-10-17",
+    "Statement": {
+        "Effect": "Allow",
+        "Action": "sts:AssumeRole",
+        "Resource": "ARN_FROM_THE_PREVIOUS_STEP"
+    }
+}
+```
+
+* In Account A, within IAM->Users->"Uername", 'Add Permission' using the Policy created in the previous step
+
 ## Setup and Configuration
 
 To configure and utilize this Opspack, you need to add the 'Cloud - AWS - CloudWatch' Opspack to the host running the EC2 software.
@@ -47,7 +72,7 @@ Step 1: Add the host template and if you are using the Public DNS name, add it t
 
 ![Add host template](/docs/img/host-template.png?raw=true)
 
-Step 2: Add and configure the 'AWS_CLOUDWATCH_AUTHENTICATION' variable with either the file location or the access key and secret key, depending on your preferred way of supplying the access credential. Add the region you hosted in (default eu-west-1). Then add and configure the 'AWS_EC2_INSTANCE_ID' by adding the instance ID if you are using it.
+Step 2: Add and configure the 'AWS_CLOUDWATCH_AUTHENTICATION' variable with either the file location or the access key and secret key, depending on your preferred way of supplying the access credential. Add the region you hosted in (default eu-west-1).  Then add and configure the 'AWS_EC2_INSTANCE_ID' by adding the instance ID and the ARN if you are using them.
 
 ![Add variable](/docs/img/variable.png?raw=true)
 

--- a/cloud-aws-ec2-cloudwatch/config.json
+++ b/cloud-aws-ec2-cloudwatch/config.json
@@ -20,7 +20,7 @@
          "arg2" : "",
          "arg3" : "",
          "arg4" : "",
-         "label1" : "",
+         "label1" : "Acccess ARN",
          "label2" : "",
          "label3" : "",
          "label4" : "",
@@ -118,7 +118,7 @@
    "servicecheck" : [
       {
          "alert_from_failure" : "1",
-         "args" : "-a $HOSTADDRESS$ -w 500 -c 800 -m 'AWS/EC2.CPUCreditBalance' -i '%AWS_EC2_INSTANCE_ID%' -f '%AWS_CLOUDWATCH_AUTHENTICATION:1%' -A '%AWS_CLOUDWATCH_AUTHENTICATION:2%' -S '%AWS_CLOUDWATCH_AUTHENTICATION:3%' -r '%AWS_CLOUDWATCH_AUTHENTICATION:4%'",
+         "args" : "-a $HOSTADDRESS$ -w 500 -c 800 -m 'AWS/EC2.CPUCreditBalance' -i '%AWS_EC2_INSTANCE_ID%' -f '%AWS_CLOUDWATCH_AUTHENTICATION:1%' -A '%AWS_CLOUDWATCH_AUTHENTICATION:2%' -S '%AWS_CLOUDWATCH_AUTHENTICATION:3%' -r '%AWS_CLOUDWATCH_AUTHENTICATION:4%' -R '%AWS_EC2_INSTANCE_ID:1%'",
          "attribute" : null,
          "calculate_rate" : "no",
          "cascaded_from" : null,
@@ -164,7 +164,7 @@
       },
       {
          "alert_from_failure" : "1",
-         "args" : "-a $HOSTADDRESS$ -w 500 -c 800 -m 'AWS/EC2.CPUCreditUsage' -i '%AWS_EC2_INSTANCE_ID%' -f '%AWS_CLOUDWATCH_AUTHENTICATION:1%' -A '%AWS_CLOUDWATCH_AUTHENTICATION:2%' -S '%AWS_CLOUDWATCH_AUTHENTICATION:3%' -r '%AWS_CLOUDWATCH_AUTHENTICATION:4%'",
+         "args" : "-a $HOSTADDRESS$ -w 500 -c 800 -m 'AWS/EC2.CPUCreditUsage' -i '%AWS_EC2_INSTANCE_ID%' -f '%AWS_CLOUDWATCH_AUTHENTICATION:1%' -A '%AWS_CLOUDWATCH_AUTHENTICATION:2%' -S '%AWS_CLOUDWATCH_AUTHENTICATION:3%' -r '%AWS_CLOUDWATCH_AUTHENTICATION:4%' -R '%AWS_EC2_INSTANCE_ID:1%'",
          "attribute" : null,
          "calculate_rate" : null,
          "cascaded_from" : null,
@@ -210,7 +210,7 @@
       },
       {
          "alert_from_failure" : "1",
-         "args" : "-a $HOSTADDRESS$ -w 80 -c 90 -m 'AWS/EC2.CPUUtilization' -i '%AWS_EC2_INSTANCE_ID%' -f '%AWS_CLOUDWATCH_AUTHENTICATION:1%' -A '%AWS_CLOUDWATCH_AUTHENTICATION:2%' -S '%AWS_CLOUDWATCH_AUTHENTICATION:3%' -r '%AWS_CLOUDWATCH_AUTHENTICATION:4%'",
+         "args" : "-a $HOSTADDRESS$ -w 80 -c 90 -m 'AWS/EC2.CPUUtilization' -i '%AWS_EC2_INSTANCE_ID%' -f '%AWS_CLOUDWATCH_AUTHENTICATION:1%' -A '%AWS_CLOUDWATCH_AUTHENTICATION:2%' -S '%AWS_CLOUDWATCH_AUTHENTICATION:3%' -r '%AWS_CLOUDWATCH_AUTHENTICATION:4%' -R '%AWS_EC2_INSTANCE_ID:1%'",
          "attribute" : null,
          "calculate_rate" : "no",
          "cascaded_from" : null,
@@ -256,7 +256,7 @@
       },
       {
          "alert_from_failure" : "1",
-         "args" : "-a $HOSTADDRESS$ -m 'AWS/EC2.DiskReadBytes' -i '%AWS_EC2_INSTANCE_ID%' -f '%AWS_CLOUDWATCH_AUTHENTICATION:1%' -A '%AWS_CLOUDWATCH_AUTHENTICATION:2%' -S '%AWS_CLOUDWATCH_AUTHENTICATION:3%' -r '%AWS_CLOUDWATCH_AUTHENTICATION:4%'",
+         "args" : "-a $HOSTADDRESS$ -m 'AWS/EC2.DiskReadBytes' -i '%AWS_EC2_INSTANCE_ID%' -f '%AWS_CLOUDWATCH_AUTHENTICATION:1%' -A '%AWS_CLOUDWATCH_AUTHENTICATION:2%' -S '%AWS_CLOUDWATCH_AUTHENTICATION:3%' -r '%AWS_CLOUDWATCH_AUTHENTICATION:4%' -R '%AWS_EC2_INSTANCE_ID:1%'",
          "attribute" : null,
          "calculate_rate" : "no",
          "cascaded_from" : null,
@@ -302,7 +302,7 @@
       },
       {
          "alert_from_failure" : "1",
-         "args" : "-a $HOSTADDRESS$ -m 'AWS/EC2.DiskReadOps' -i '%AWS_EC2_INSTANCE_ID%' -f '%AWS_CLOUDWATCH_AUTHENTICATION:1%' -A '%AWS_CLOUDWATCH_AUTHENTICATION:2%' -S '%AWS_CLOUDWATCH_AUTHENTICATION:3%' -r '%AWS_CLOUDWATCH_AUTHENTICATION:4%'",
+         "args" : "-a $HOSTADDRESS$ -m 'AWS/EC2.DiskReadOps' -i '%AWS_EC2_INSTANCE_ID%' -f '%AWS_CLOUDWATCH_AUTHENTICATION:1%' -A '%AWS_CLOUDWATCH_AUTHENTICATION:2%' -S '%AWS_CLOUDWATCH_AUTHENTICATION:3%' -r '%AWS_CLOUDWATCH_AUTHENTICATION:4%' -R '%AWS_EC2_INSTANCE_ID:1%'",
          "attribute" : null,
          "calculate_rate" : "no",
          "cascaded_from" : null,
@@ -348,7 +348,7 @@
       },
       {
          "alert_from_failure" : "1",
-         "args" : "-a $HOSTADDRESS$ -m 'AWS/EC2.DiskWriteBytes' -i '%AWS_EC2_INSTANCE_ID%' -f '%AWS_CLOUDWATCH_AUTHENTICATION:1%' -A '%AWS_CLOUDWATCH_AUTHENTICATION:2%' -S '%AWS_CLOUDWATCH_AUTHENTICATION:3%' -r '%AWS_CLOUDWATCH_AUTHENTICATION:4%'",
+         "args" : "-a $HOSTADDRESS$ -m 'AWS/EC2.DiskWriteBytes' -i '%AWS_EC2_INSTANCE_ID%' -f '%AWS_CLOUDWATCH_AUTHENTICATION:1%' -A '%AWS_CLOUDWATCH_AUTHENTICATION:2%' -S '%AWS_CLOUDWATCH_AUTHENTICATION:3%' -r '%AWS_CLOUDWATCH_AUTHENTICATION:4%' -R '%AWS_EC2_INSTANCE_ID:1%'",
          "attribute" : null,
          "calculate_rate" : "no",
          "cascaded_from" : null,
@@ -394,7 +394,7 @@
       },
       {
          "alert_from_failure" : "1",
-         "args" : "-a $HOSTADDRESS$ -m 'AWS/EC2.DiskWriteOps' -i '%AWS_EC2_INSTANCE_ID%' -f '%AWS_CLOUDWATCH_AUTHENTICATION:1%' -A '%AWS_CLOUDWATCH_AUTHENTICATION:2%' -S '%AWS_CLOUDWATCH_AUTHENTICATION:3%' -r '%AWS_CLOUDWATCH_AUTHENTICATION:4%'",
+         "args" : "-a $HOSTADDRESS$ -m 'AWS/EC2.DiskWriteOps' -i '%AWS_EC2_INSTANCE_ID%' -f '%AWS_CLOUDWATCH_AUTHENTICATION:1%' -A '%AWS_CLOUDWATCH_AUTHENTICATION:2%' -S '%AWS_CLOUDWATCH_AUTHENTICATION:3%' -r '%AWS_CLOUDWATCH_AUTHENTICATION:4%' -R '%AWS_EC2_INSTANCE_ID:1%'",
          "attribute" : null,
          "calculate_rate" : "no",
          "cascaded_from" : null,
@@ -440,7 +440,7 @@
       },
       {
          "alert_from_failure" : "1",
-         "args" : "-a $HOSTADDRESS$ -m 'AWS/EC2.NetworkIn' -i '%AWS_EC2_INSTANCE_ID%' -f '%AWS_CLOUDWATCH_AUTHENTICATION:1%' -A '%AWS_CLOUDWATCH_AUTHENTICATION:2%' -S '%AWS_CLOUDWATCH_AUTHENTICATION:3%' -r '%AWS_CLOUDWATCH_AUTHENTICATION:4%'",
+         "args" : "-a $HOSTADDRESS$ -m 'AWS/EC2.NetworkIn' -i '%AWS_EC2_INSTANCE_ID%' -f '%AWS_CLOUDWATCH_AUTHENTICATION:1%' -A '%AWS_CLOUDWATCH_AUTHENTICATION:2%' -S '%AWS_CLOUDWATCH_AUTHENTICATION:3%' -r '%AWS_CLOUDWATCH_AUTHENTICATION:4%' -R '%AWS_EC2_INSTANCE_ID:1%'",
          "attribute" : null,
          "calculate_rate" : "no",
          "cascaded_from" : null,
@@ -486,7 +486,7 @@
       },
       {
          "alert_from_failure" : "1",
-         "args" : "-a $HOSTADDRESS$ -m 'AWS/EC2.NetworkOut' -i '%AWS_EC2_INSTANCE_ID%' -f '%AWS_CLOUDWATCH_AUTHENTICATION:1%' -A '%AWS_CLOUDWATCH_AUTHENTICATION:2%' -S '%AWS_CLOUDWATCH_AUTHENTICATION:3%' -r '%AWS_CLOUDWATCH_AUTHENTICATION:4%'",
+         "args" : "-a $HOSTADDRESS$ -m 'AWS/EC2.NetworkOut' -i '%AWS_EC2_INSTANCE_ID%' -f '%AWS_CLOUDWATCH_AUTHENTICATION:1%' -A '%AWS_CLOUDWATCH_AUTHENTICATION:2%' -S '%AWS_CLOUDWATCH_AUTHENTICATION:3%' -r '%AWS_CLOUDWATCH_AUTHENTICATION:4%' -R '%AWS_EC2_INSTANCE_ID:1%'",
          "attribute" : null,
          "calculate_rate" : "no",
          "cascaded_from" : null,
@@ -532,7 +532,7 @@
       },
       {
          "alert_from_failure" : "1",
-         "args" : "-a $HOSTADDRESS$ -m 'AWS/EC2.NetworkPacketsIn' -i '%AWS_EC2_INSTANCE_ID%' -f '%AWS_CLOUDWATCH_AUTHENTICATION:1%' -A '%AWS_CLOUDWATCH_AUTHENTICATION:2%' -S '%AWS_CLOUDWATCH_AUTHENTICATION:3%' -r '%AWS_CLOUDWATCH_AUTHENTICATION:4%'",
+         "args" : "-a $HOSTADDRESS$ -m 'AWS/EC2.NetworkPacketsIn' -i '%AWS_EC2_INSTANCE_ID%' -f '%AWS_CLOUDWATCH_AUTHENTICATION:1%' -A '%AWS_CLOUDWATCH_AUTHENTICATION:2%' -S '%AWS_CLOUDWATCH_AUTHENTICATION:3%' -r '%AWS_CLOUDWATCH_AUTHENTICATION:4%' -R '%AWS_EC2_INSTANCE_ID:1%'",
          "attribute" : null,
          "calculate_rate" : "no",
          "cascaded_from" : null,
@@ -578,7 +578,7 @@
       },
       {
          "alert_from_failure" : "1",
-         "args" : "-a $HOSTADDRESS$ -m 'AWS/EC2.NetworkPacketsOut' -i '%AWS_EC2_INSTANCE_ID%' -f '%AWS_CLOUDWATCH_AUTHENTICATION:1%' -A '%AWS_CLOUDWATCH_AUTHENTICATION:2%' -S '%AWS_CLOUDWATCH_AUTHENTICATION:3%' -r '%AWS_CLOUDWATCH_AUTHENTICATION:4%'",
+         "args" : "-a $HOSTADDRESS$ -m 'AWS/EC2.NetworkPacketsOut' -i '%AWS_EC2_INSTANCE_ID%' -f '%AWS_CLOUDWATCH_AUTHENTICATION:1%' -A '%AWS_CLOUDWATCH_AUTHENTICATION:2%' -S '%AWS_CLOUDWATCH_AUTHENTICATION:3%' -r '%AWS_CLOUDWATCH_AUTHENTICATION:4%' -R '%AWS_EC2_INSTANCE_ID:1%'",
          "attribute" : null,
          "calculate_rate" : "no",
          "cascaded_from" : null,
@@ -624,7 +624,7 @@
       },
       {
          "alert_from_failure" : "1",
-         "args" : "-a $HOSTADDRESS$ -m 'AWS/EC2.StatusCheckFailed' -i '%AWS_EC2_INSTANCE_ID%' -f '%AWS_CLOUDWATCH_AUTHENTICATION:1%' -A '%AWS_CLOUDWATCH_AUTHENTICATION:2%' -S '%AWS_CLOUDWATCH_AUTHENTICATION:3%' -r '%AWS_CLOUDWATCH_AUTHENTICATION:4%'",
+         "args" : "-a $HOSTADDRESS$ -m 'AWS/EC2.StatusCheckFailed' -i '%AWS_EC2_INSTANCE_ID%' -f '%AWS_CLOUDWATCH_AUTHENTICATION:1%' -A '%AWS_CLOUDWATCH_AUTHENTICATION:2%' -S '%AWS_CLOUDWATCH_AUTHENTICATION:3%' -r '%AWS_CLOUDWATCH_AUTHENTICATION:4%' -R '%AWS_EC2_INSTANCE_ID:1%'",
          "attribute" : null,
          "calculate_rate" : "no",
          "cascaded_from" : null,

--- a/cloud-aws-ec2-cloudwatch/info
+++ b/cloud-aws-ec2-cloudwatch/info
@@ -1,5 +1,5 @@
 NAME=com.opsview.opspack.cloud_aws_ec2_cloudwatch
-VERSION=1.0
+VERSION=1.1
 ALIAS=Cloud - AWS - EC2 CloudWatch
 DEPENDENCIES=
 OPSVIEW_MIN_VERSION=


### PR DESCRIPTION
Add functionality to use the access key in one account but check an EC2
instance in a different one.  This is achieved by using AWS Roles and ARNs
set up between the two accounts.

SC:18614, ODI-658